### PR TITLE
Remove new lines from title in PSItemViewHelper

### DIFF
--- a/Classes/ViewHelpers/PhotoswipeItemViewHelper.php
+++ b/Classes/ViewHelpers/PhotoswipeItemViewHelper.php
@@ -92,7 +92,7 @@ class PhotoswipeItemViewHelper extends AbstractViewHelper
             $result .= ",\n msrc:'".$imageService->getImageUri($processedMsrc)."'";
         }
         if (!empty($properties['description'])) {
-            $result .= ",\n title:'".$properties['description']."'";
+	    $result .= ",\n title:'" . trim(preg_replace('/\s+/', ' ', $properties['description'])) ."'";
         }
         //if (!empty($properties['author'])) {$result .= ",\n author'".$properties['author']."'";}
         $result .= "\n}";

--- a/Classes/ViewHelpers/PhotoswipeItemViewHelper.php
+++ b/Classes/ViewHelpers/PhotoswipeItemViewHelper.php
@@ -92,7 +92,11 @@ class PhotoswipeItemViewHelper extends AbstractViewHelper
             $result .= ",\n msrc:'".$imageService->getImageUri($processedMsrc)."'";
         }
         if (!empty($properties['description'])) {
-	    $result .= ",\n title:'" . trim(preg_replace('/\s+/', ' ', $properties['description'])) ."'";
+	    /** @var ContentObjectRenderer $contentObject */
+            $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+            $description = $contentObject->parseFunc(trim($properties['description']), [], '< lib.parseFunc_RTE');
+            $parsedDescription = preg_replace("/\r|\n/", "", $description);
+            $result .= ",\n title:'". str_replace("'", "\'", $parsedDescription)."'";
         }
         //if (!empty($properties['author'])) {$result .= ",\n author'".$properties['author']."'";}
         $result .= "\n}";


### PR DESCRIPTION
Should the description property of a file reference contain a new line, the whole FE rendering of PS items breaks.
By trimming and replacing new lines before outputting them, it is now possible to render longer descriptions with/without html.

Clean up based on: http://stackoverflow.com/a/3760830/1788026